### PR TITLE
Se permite establecer el total para evitar problemas de redondeo con las cuotas

### DIFF
--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -55,6 +55,11 @@ class Payment extends AbstractModel
      * @var string
      */
     protected $CardPromotionCode;
+    /**
+     * Total, del pago.
+     * @var float
+     */
+    protected $PaymentTotal = null;
 
     /**
      * Getter for AuthorizationCode
@@ -258,6 +263,9 @@ class Payment extends AbstractModel
      */
     public function getTotal()
     {
+        if ($this->PaymentTotal !== null) {
+            return $this->PaymentTotal;
+        }
         return $this->getInstallments() * $this->getInstallmentAmount();
     }
 
@@ -348,5 +356,18 @@ class Payment extends AbstractModel
         return $data + [
                 'Total' => $this->getTotal(),
             ];
+    }
+
+    /**
+     * Setter for PaymentTotal
+     *
+     * @param float $PaymentTotal
+     *
+     * @return self
+     */
+    public function setPaymentTotal($PaymentTotal)
+    {
+        $this->PaymentTotal = $PaymentTotal;
+        return $this;
     }
 }


### PR DESCRIPTION
Debido al redondeo que ocurre eventualmente, se permite establecer el total pagado para que coincida con el total pedido